### PR TITLE
[3주차] TodoList 만들기

### DIFF
--- a/week3/JungSangHyun/index.css
+++ b/week3/JungSangHyun/index.css
@@ -1,0 +1,73 @@
+body {
+  background-color: #f5f5f5;
+  padding: 30px;
+}
+
+.container {
+  max-width: 500px;
+  margin: 0 auto;
+  background: white;
+  padding: 20px 30px;
+  border-radius: 10px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+h1 {
+  text-align: center;
+}
+
+form {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+input[type="text"] {
+  flex: 1;
+  padding: 10px;
+  font-size: 16px;
+}
+
+button {
+  padding: 10px 20px;
+  font-size: 16px;
+  background-color: #4caf50;
+  color: white;
+  border: none;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #45a049;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+li {
+  padding: 10px;
+  border-bottom: 1px solid #ddd;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+li.done {
+  text-decoration: line-through;
+  color: gray;
+}
+
+li button {
+  background-color: #f44336;
+  border: none;
+  padding: 5px 10px;
+  color: white;
+  cursor: pointer;
+  margin-left: 10px;
+}
+
+li button:hover {
+  background-color: #d32f2f;
+}

--- a/week3/JungSangHyun/index.css
+++ b/week3/JungSangHyun/index.css
@@ -54,7 +54,7 @@ li {
   align-items: center;
 }
 
-li.done {
+li.done span{
   text-decoration: line-through;
   color: gray;
 }

--- a/week3/JungSangHyun/index.css
+++ b/week3/JungSangHyun/index.css
@@ -1,3 +1,6 @@
+* {
+    box-sizing: border-box; /* padding/border까지 포함해서 계산 */
+}
 body {
   background-color: #f5f5f5;
   padding: 30px;
@@ -96,4 +99,14 @@ li.done span{
 
 .todo-list__button--update:hover {
   background-color: #263dc4;
+}
+
+.todo-list__input--update {
+  display:flex;
+  width: 100%;
+  justify-content: space-between;
+}
+
+#todo-update-input {
+  flex: 1;
 }

--- a/week3/JungSangHyun/index.css
+++ b/week3/JungSangHyun/index.css
@@ -54,12 +54,25 @@ li {
   align-items: center;
 }
 
+li span{
+  display: block;
+  flex:1; /*버튼 영역 제외 나머지 공간 차지*/
+  white-space: normal; /*글자 넘치면 줄 바꿈*/
+}
+
 li.done span{
   text-decoration: line-through;
   color: gray;
 }
 
-li button {
+.todo-list__button {
+  display: flex;
+  width: 120px;
+  justify-content: end;
+  flex-shrink: 0; /*width 항상 유지*/
+}
+
+.todo-list__button--delete {
   background-color: #f44336;
   border: none;
   padding: 5px 10px;
@@ -68,6 +81,19 @@ li button {
   margin-left: 10px;
 }
 
-li button:hover {
+.todo-list__button--delete:hover {
   background-color: #d32f2f;
+}
+
+.todo-list__button--update {
+  background-color: #254af3;
+  border: none;
+  padding: 5px 10px;
+  color: white;
+  cursor: pointer;
+  margin-left: 10px;
+}
+
+.todo-list__button--update:hover {
+  background-color: #263dc4;
 }

--- a/week3/JungSangHyun/index.html
+++ b/week3/JungSangHyun/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Todo App</title>
+    <link rel="stylesheet" href="index.css" />
+  </head>
+  <body>
+    <div class="container">
+      <h1>Todo List</h1>
+      <form id="todo-form">
+        <input
+          type="text"
+          id="todo-input"
+          placeholder="할 일을 입력하세요"
+          required
+        />
+        <button type="submit">추가</button>
+      </form>
+      <ul id="todo-list"></ul>
+    </div>
+
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/week3/JungSangHyun/index.html
+++ b/week3/JungSangHyun/index.html
@@ -14,7 +14,7 @@
           type="text"
           id="todo-input"
           placeholder="할 일을 입력하세요"
-          required
+          required 
         />
         <button type="submit">추가</button>
       </form>

--- a/week3/JungSangHyun/index.js
+++ b/week3/JungSangHyun/index.js
@@ -1,9 +1,16 @@
-let todos = [];
+let todos = JSON.parse(localStorage.getItem("todos")) || [];
 
 // DOM에서 태그를 가리키는 객체 -> DOM조작 메소드 사용가능 
 const form = document.getElementById("todo-form");
 const input = document.getElementById("todo-input");
 const list = document.getElementById("todo-list");
+
+render();
+
+// localStorage 저장 함수
+function saveTodos() {
+  localStorage.setItem("todos", JSON.stringify(todos));
+}
 
 form.addEventListener("submit", (e) => {
   e.preventDefault(); 
@@ -15,13 +22,15 @@ form.addEventListener("submit", (e) => {
       done: false,
     };
     todos.push(newTodo);
+    saveTodos();
     render(); // 화면 동기화 
   }
 });
 
 function deleteTodo(id) {
-  todos = todos.filter(todo => todo.id !== id)
+  todos = todos.filter(todo => todo.id !== id);
 
+  saveTodos();
   render();
 }
 
@@ -33,6 +42,7 @@ function toggleDone(todo) {
     todo.done = true;
   }
 
+  saveTodos();
   render();
 }
 
@@ -51,40 +61,37 @@ function render() {
     buttonDiv.className = "todo-list__button";
 
     const delBtn = document.createElement("button");
-    delBtn.className = "todo-list__button--delete"
+    delBtn.className = "todo-list__button--delete";
     delBtn.textContent = "삭제";
     delBtn.onclick = () => deleteTodo(todo.id);
 
     const updateBtn = document.createElement("button");
-    updateBtn.className = "todo-list__button--update"
+    updateBtn.className = "todo-list__button--update";
     updateBtn.textContent = "수정";
     updateBtn.onclick = () => updateTodo(todo, li); // 현재 <li>를 넘겨야 remove가능 
 
     li.appendChild(span);
-    li.appendChild(buttonDiv)
+    li.appendChild(buttonDiv);
     buttonDiv.appendChild(delBtn);
     buttonDiv.appendChild(updateBtn);
     list.appendChild(li);
   });
 }
 
-// todo localStorage 사용까지 
-
-// JS로 삭제버튼 만든 것 처럼 만들기 
 function updateTodo(todo, li) {
   li.innerHTML = ""; // 해당 <li>의 자식 요소 제거 
 
   const updateDiv = document.createElement("div");
-  updateDiv.className = "todo-list__input--update"
+  updateDiv.className = "todo-list__input--update";
 
   const updateInput = document.createElement("input");
-  updateInput.id = "todo-update-input"
+  updateInput.id = "todo-update-input";
   updateInput.required = true; // 입력값 필요
-  updateInput.placeholder = todo.text
+  updateInput.placeholder = todo.text;
 
   const updateInputButton = document.createElement("button");
   updateInputButton.className = "todo-list__button--update";
-  updateInputButton.textContent = "수정"
+  updateInputButton.textContent = "수정";
 
   updateDiv.appendChild(updateInput);
   updateDiv.appendChild(updateInputButton);
@@ -99,6 +106,8 @@ function updateTodo(todo, li) {
     }
     todo.text = updateInput.value;
     updateDiv.remove(); // 수정 form 삭제
+
+    saveTodos();
     render();
   }
 }

--- a/week3/JungSangHyun/index.js
+++ b/week3/JungSangHyun/index.js
@@ -1,11 +1,12 @@
 let todos = [];
 
+// DOM에서 태그를 가리키는 객체 -> DOM조작 메소드 사용가능 
 const form = document.getElementById("todo-form");
 const input = document.getElementById("todo-input");
 const list = document.getElementById("todo-list");
 
 form.addEventListener("submit", (e) => {
-  e.preventDefault();
+  e.preventDefault(); 
   const text = input.value.trim();
   if (text) {
     const newTodo = {
@@ -18,12 +19,25 @@ form.addEventListener("submit", (e) => {
   }
 });
 
-function deleteTodo(id) {}
+function deleteTodo(id) {
+  todos = todos.filter(todo => todo.id !== id)
 
-function toggleDone(id) {}
+  render();
+}
+
+function toggleDone(todo) {
+  if (todo.done) {
+    todo.done = false;
+  }
+  else {
+    todo.done = true;
+  }
+
+  render();
+}
 
 function render() {
-  list.innerHTML = "";
+  list.innerHTML = ""; // todo-list 초기화 
   todos.forEach((todo) => {
     const li = document.createElement("li");
     li.className = todo.done ? "done" : "";
@@ -31,17 +45,24 @@ function render() {
     const span = document.createElement("span");
     span.textContent = todo.text;
     span.style.cursor = "pointer";
-    span.onclick = () => toggleDone(todo.id);
+    span.onclick = () => toggleDone(todo);
 
     const delBtn = document.createElement("button");
     delBtn.textContent = "삭제";
     delBtn.onclick = () => deleteTodo(todo.id);
 
+    const updateBtn = document.createElement("button");
+    updateBtn.textContent = "수정";
+    updateBtn.onclick = () => updateTodo(todo.id);
+
     li.appendChild(span);
     li.appendChild(delBtn);
+    li.appendChild(updateBtn);
     list.appendChild(li);
   });
 }
+
+// todo localStorage 사용까지 
 
 // JS로 삭제버튼 만든 것 처럼 만들기 
 function updateTodo() {

--- a/week3/JungSangHyun/index.js
+++ b/week3/JungSangHyun/index.js
@@ -47,17 +47,23 @@ function render() {
     span.style.cursor = "pointer";
     span.onclick = () => toggleDone(todo);
 
+    const buttonDiv = document.createElement("div");
+    buttonDiv.className = "todo-list__button";
+
     const delBtn = document.createElement("button");
+    delBtn.className = "todo-list__button--delete"
     delBtn.textContent = "삭제";
     delBtn.onclick = () => deleteTodo(todo.id);
 
     const updateBtn = document.createElement("button");
+    updateBtn.className = "todo-list__button--update"
     updateBtn.textContent = "수정";
     updateBtn.onclick = () => updateTodo(todo.id);
 
     li.appendChild(span);
-    li.appendChild(delBtn);
-    li.appendChild(updateBtn);
+    li.appendChild(buttonDiv)
+    buttonDiv.appendChild(delBtn);
+    buttonDiv.appendChild(updateBtn);
     list.appendChild(li);
   });
 }

--- a/week3/JungSangHyun/index.js
+++ b/week3/JungSangHyun/index.js
@@ -1,0 +1,52 @@
+let todos = [];
+
+const form = document.getElementById("todo-form");
+const input = document.getElementById("todo-input");
+const list = document.getElementById("todo-list");
+
+form.addEventListener("submit", (e) => {
+  e.preventDefault();
+  const text = input.value.trim();
+  if (text) {
+    const newTodo = {
+      id: Date.now(),
+      text,
+      done: false,
+    };
+    todos.push(newTodo);
+    render(); // 화면 동기화 
+  }
+});
+
+function deleteTodo(id) {}
+
+function toggleDone(id) {}
+
+function render() {
+  list.innerHTML = "";
+  todos.forEach((todo) => {
+    const li = document.createElement("li");
+    li.className = todo.done ? "done" : "";
+
+    const span = document.createElement("span");
+    span.textContent = todo.text;
+    span.style.cursor = "pointer";
+    span.onclick = () => toggleDone(todo.id);
+
+    const delBtn = document.createElement("button");
+    delBtn.textContent = "삭제";
+    delBtn.onclick = () => deleteTodo(todo.id);
+
+    li.appendChild(span);
+    li.appendChild(delBtn);
+    list.appendChild(li);
+  });
+}
+
+// JS로 삭제버튼 만든 것 처럼 만들기 
+function updateTodo() {
+  // 수정 버튼 클릭시
+  // 각 Li요소에 input 태그, 버튼 등장
+  // id와 done은 변경 X (다른 상태들)
+  // 버튼 누르면 Input 태그 사라지고, todo가 수정 완료 
+}

--- a/week3/JungSangHyun/index.js
+++ b/week3/JungSangHyun/index.js
@@ -58,7 +58,7 @@ function render() {
     const updateBtn = document.createElement("button");
     updateBtn.className = "todo-list__button--update"
     updateBtn.textContent = "수정";
-    updateBtn.onclick = () => updateTodo(todo.id);
+    updateBtn.onclick = () => updateTodo(todo, li); // 현재 <li>를 넘겨야 remove가능 
 
     li.appendChild(span);
     li.appendChild(buttonDiv)
@@ -71,9 +71,34 @@ function render() {
 // todo localStorage 사용까지 
 
 // JS로 삭제버튼 만든 것 처럼 만들기 
-function updateTodo() {
-  // 수정 버튼 클릭시
-  // 각 Li요소에 input 태그, 버튼 등장
-  // id와 done은 변경 X (다른 상태들)
-  // 버튼 누르면 Input 태그 사라지고, todo가 수정 완료 
+function updateTodo(todo, li) {
+  li.innerHTML = ""; // 해당 <li>의 자식 요소 제거 
+
+  const updateDiv = document.createElement("div");
+  updateDiv.className = "todo-list__input--update"
+
+  const updateInput = document.createElement("input");
+  updateInput.id = "todo-update-input"
+  updateInput.required = true; // 입력값 필요
+  updateInput.placeholder = todo.text
+
+  const updateInputButton = document.createElement("button");
+  updateInputButton.className = "todo-list__button--update";
+  updateInputButton.textContent = "수정"
+
+  updateDiv.appendChild(updateInput);
+  updateDiv.appendChild(updateInputButton);
+  li.appendChild(updateDiv);
+
+  updateInputButton.onclick = () => {
+    if (updateInput.value.trim() === "") {
+      alert("값을 입력하세요!");
+      render();
+
+      return;
+    }
+    todo.text = updateInput.value;
+    updateDiv.remove(); // 수정 form 삭제
+    render();
+  }
 }


### PR DESCRIPTION
## 📚 워크북 링크

https://tropical-lipstick-3e5.notion.site/3-JavaScript-27befa9e4fe980feabebcf86c5214576?source=copy_link

## 📝 변경/추가 사항 요약

- 추가 / 삭제 / 수정 기능 구현
- 수정 시 입력 값이 있어야 수정 되도록 구현 
- localStorage로 todo-list 저장 

## ✅ 리뷰 요구사항

1. 워크북에 주어진 힌트대로 해당 li 태그의 자식요소들을 삭제하고 새로운 input 태그와 button 태그를 생성후에 li.appendChild 했는데 boolean 변수를 두어서 수정버튼의 클릭 유무에 따라 li 태그 내부의 요소들을 조건부 렌더링 하는 방식과 비교 했을때 어떤 방식이 더 나은지 궁금합니다.

2. 개선 할 부분 있으면 알려주시면 감사하겠습니다.

## 📸 확인 방법 (스크린샷)
1. localStorage로 불러온 화면, input form에 '쿠잇' 입력 
<img width="793" height="643" alt="image" src="https://github.com/user-attachments/assets/ca9d7a48-177d-4262-8e7d-dca6528e688d" />

2. '쿠잇' -> '쿠잇 미션'으로 수정 
<img width="793" height="632" alt="image" src="https://github.com/user-attachments/assets/d37fa043-d00e-4973-bea9-2689a9c7d3a8" />

3. 수정 완료 결과
<img width="790" height="692" alt="image" src="https://github.com/user-attachments/assets/435c6461-0c2d-4d97-90e4-27bbda518189" />

<제출 전 체크리스트>

- ✔️ week00 폴더 내에 자신의 폴더를 새로 만드셨나요?
- ✔️ 자신 폴더 외의 다른 사람의 폴더에서 코드를 수정하지 않았나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 브라우저 기반 To‑Do 앱 추가: 항목 추가, 완료/해제, 인라인 수정, 삭제 지원
  - 로컬 저장소 연동으로 항목과 상태 자동 저장·복원
  - 빈 입력 방지 및 수정 시 공백 경고 등 기본 유효성 검사

- 스타일
  - 중앙 정렬 컨테이너, 라운드/그림자, 반응형 폼 레이아웃 적용
  - 버튼(추가·수정·삭제) 색상 및 호버 효과 개선
  - 목록 가독성 향상: 구분선, 완료 항목 취소선·회색 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->